### PR TITLE
fixes state when server is behind NAT

### DIFF
--- a/src/nm-l2tp-service.c
+++ b/src/nm-l2tp-service.c
@@ -676,9 +676,7 @@ nm_l2tp_config_write (NML2tpPlugin *plugin,
 	write_config_option (ipsec_fd, 		"  auto=add\n"
 						"  type=transport\n");
 
-	write_config_option (ipsec_fd, 		"  right=%%any\n"
-						"  rightid=%%any\n"
-						"  authby=secret\n"
+	write_config_option (ipsec_fd,	"  authby=secret\n"
 						"  keyingtries=0\n"
 						"  left=%%defaultroute\n"
 						"  leftprotoport=udp/l2tp\n"
@@ -709,6 +707,8 @@ nm_l2tp_config_write (NML2tpPlugin *plugin,
 		} else {
 			write_config_option (ipsec_fd, "  rightid=%s\n", value);
 		}
+	} else {
+		write_config_option (ipsec_fd, "  rightid=%%any\n");
 	}
 
 	if (priv->is_libreswan) {
@@ -860,7 +860,7 @@ nm_l2tp_config_write (NML2tpPlugin *plugin,
 		write_config_option (pppopt_fd, "mtu 1400\n");
 	}
 
-	/*	
+	/*
 	if (priv && priv->use_cert) {
 		write_config_option (pppopt_fd, "cert \"%s\"\n", nm_setting_vpn_get_data_item (s_vpn, NM_L2TP_KEY_CERT_PUB));
 		write_config_option (pppopt_fd, "ca \"%s\"\n", nm_setting_vpn_get_data_item (s_vpn, NM_L2TP_KEY_CERT_CA));

--- a/src/nm-l2tp-service.c
+++ b/src/nm-l2tp-service.c
@@ -676,7 +676,9 @@ nm_l2tp_config_write (NML2tpPlugin *plugin,
 	write_config_option (ipsec_fd, 		"  auto=add\n"
 						"  type=transport\n");
 
-	write_config_option (ipsec_fd, 		"  authby=secret\n"
+	write_config_option (ipsec_fd, 		"  right=%%any\n"
+						"  rightid=%%any\n"
+						"  authby=secret\n"
 						"  keyingtries=0\n"
 						"  left=%%defaultroute\n"
 						"  leftprotoport=udp/l2tp\n"


### PR DESCRIPTION
I spent many hours to establish a connection to my VPN server which is behind NAT. 
Strongswan rejects connection with the message "IDir '172.30.20.83' does not match to '...' " .
My fix just tells strongswan to disable the check.