### PR TITLE
rpmlint warning dbus-policy-allow-without-destination

### DIFF
--- a/nm-l2tp-service.conf
+++ b/nm-l2tp-service.conf
@@ -4,8 +4,8 @@
 <busconfig>
 	<policy user="root">
 		<allow own_prefix="org.freedesktop.NetworkManager.l2tp"/>
-		<allow send_destination="org.freedesktop.NetworkManager.l2tp"/>
-		<allow send_interface="org.freedesktop.NetworkManager.l2tp.ppp"/>
+		<allow send_destination="org.freedesktop.NetworkManager.l2tp"
+		       send_interface="org.freedesktop.NetworkManager.l2tp.ppp"/>
 	</policy>
 	<policy context="default">
 		<deny own_prefix="org.freedesktop.NetworkManager.l2tp"/>


### PR DESCRIPTION
This limits messages with interface org.freedesktop.NetworkManager.l2tp.ppp to be sent only to dbus-policy-allow-without-destination.

This is untested change, but may work.
Reference:
  * https://lintian.debian.org/tags/dbus-policy-without-send-destination.html
  * https://github.com/mate-desktop/mate-applets/issues/46