### PR TITLE
properties: don't assume the error argument is present

### DIFF
--- a/properties/nm-l2tp-editor-plugin.c
+++ b/properties/nm-l2tp-editor-plugin.c
@@ -80,9 +80,6 @@ import (NMVpnEditorPlugin *iface, const char *path, GError **error)
 
 	connection = do_import (path, error);
 
-	if ((connection == NULL) && (*error != NULL))
-		g_warning("Can't import file as L2TP config: %s", (*error)->message);
-
 	return connection;
 }
 


### PR DESCRIPTION
It's customary to allow NULL error when the caller decides to ignore an
error condition (and it may actually choose to do so, in which case this
will dereference a NULL pointer).