### PR TITLE
build: disable libnm-glib support by default

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,13 @@
+==========================================================
+NetworkManager-l2tp-1.8.0 (not released yet)
+Overview of changes since network-manager-l2tp-1.2.10
+==========================================================
+
+* libnm-glib compatibility (NetworkManager < 1.0) is disabled by default.
+  It can be enabled by passing --with-libnm-glib to configure script.
+  Nobody should need it by now. Users that still use this are encouraged
+  to let us know before the libnm-glib support is removed for good.
+
 =======================================================
 NetworkManager-l2tp-1.2.10
 Overview of changes since network-manager-l2tp-1.2.8

--- a/configure.ac
+++ b/configure.ac
@@ -101,7 +101,7 @@ dnl
 dnl GNOME support
 dnl
 AC_ARG_WITH(gnome, AS_HELP_STRING([--without-gnome], [Build NetworkManager-l2tp without GNOME support, e.g. vpn service only]), [], [with_gnome_specified=no])
-AC_ARG_WITH(libnm-glib, AS_HELP_STRING([--without-libnm-glib], [Build NetworkManager-l2tp without libnm-glib comatibility]), [], [with_libnm_glib_specified=no])
+AC_ARG_WITH(libnm-glib, AS_HELP_STRING([--with-libnm-glib], [Build NetworkManager-l2tp with libnm-glib comatibility (depreacted)]), [], [with_libnm_glib_specified=no])
 if test "$with_libnm_glib_specified" != no -a "$with_libnm_glib" != no; then
 	if test "$with_gnome_specified" != no -a "$with_gnome" == no; then
 		AC_MSG_ERROR(Building --with-libnm-glib conflicts with --without-gnome)
@@ -111,10 +111,10 @@ if test "$with_gnome" != no; then
 	with_gnome=yes
 fi
 if test "$with_libnm_glib_specified" == no; then
-	with_libnm_glib="$with_gnome"
+	with_libnm_glib=no
 fi
-if test "$with_libnm_glib" != no; then
-	with_libnm_glib=yes
+if test "$with_libnm_glib" != yes; then
+	with_libnm_glib=no
 fi
 AM_CONDITIONAL(WITH_GNOME, test "$with_gnome" != no)
 AM_CONDITIONAL(WITH_LIBNM_GLIB, test "$with_libnm_glib" != no)


### PR DESCRIPTION
By now nobody should be using this. Keep the code around for a little
longer just in case anybody still uses this.

The libnm-glib support also serves as an example how do we build two
different versions of the properties plugin. We'll soon be in a similar
situation with Gtk 4.0. (sigh.) Just don't drop it yet.