### PR TITLE
auth-dialog: don't connect to Gtk+ display until necessary

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,9 @@ Overview of changes since network-manager-l2tp-1.2.10
   It can be enabled by passing --with-libnm-glib to configure script.
   Nobody should need it by now. Users that still use this are encouraged
   to let us know before the libnm-glib support is removed for good.
+* The auth helper in external UI mode can now be run without a display
+  server. Future nmcli version will utilize this for handling the
+  secrets without a graphical desktop.
 
 =======================================================
 NetworkManager-l2tp-1.2.10

--- a/auth-dialog/main.c
+++ b/auth-dialog/main.c
@@ -18,7 +18,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * (C) Copyright 2004 - 2011 Red Hat, Inc.
+ * (C) Copyright 2004 - 2018 Red Hat, Inc.
  *               2005 Tim Niemueller [www.niemueller.de]
  */
 
@@ -229,6 +229,8 @@ std_ask_user (const char *vpn_name,
 	g_return_val_if_fail (out_new_password != NULL, FALSE);
 	g_return_val_if_fail (out_new_certpass != NULL, FALSE);
 	g_return_val_if_fail (out_new_ipsec_certpass != NULL, FALSE);
+
+	gtk_init (NULL, NULL);
 
 	dialog = NMA_VPN_PASSWORD_DIALOG (nma_vpn_password_dialog_new (_("Authenticate VPN"), prompt, NULL));
 
@@ -448,10 +450,9 @@ main (int argc, char *argv[])
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
 
-	gtk_init (&argc, &argv);
-
 	context = g_option_context_new ("- l2tp auth dialog");
 	g_option_context_add_main_entries (context, entries, GETTEXT_PACKAGE);
+	g_option_context_add_group (context, gtk_get_option_group (FALSE));
 	g_option_context_parse (context, &argc, &argv, NULL);
 	g_option_context_free (context);
 


### PR DESCRIPTION
In the external UI mode we may end up not needing a connection to the
display server at all.

This splits the parsing of Gtk+ command line arguments from connection
to the display. This also fixes the --help output to actually include
the Gtk+ arguments (such as --display).